### PR TITLE
Improve error handling for missing websearch tools

### DIFF
--- a/backend/migrations/versions/f6a1b2c3d4e5_create_normalized_metadata.py
+++ b/backend/migrations/versions/f6a1b2c3d4e5_create_normalized_metadata.py
@@ -183,4 +183,3 @@ def downgrade() -> None:
         sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
         sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now()),
     )
-

--- a/backend/routes/llama_stack.py
+++ b/backend/routes/llama_stack.py
@@ -541,7 +541,17 @@ async def chat(
 
             except Exception as e:
                 log.error(f"Error in stream: {str(e)}")
-                yield (f'data: {{"type":"error","content":"Error: {str(e)}"}}\n\n')
+
+                # Handle specific websearch tool error with user-friendly message
+                error_message = str(e)
+                if "Tool group 'builtin::websearch' not found" in error_message:
+                    error_message = (
+                        "This assistant is not available right now. It needs internet search tools "
+                        "(such as Tavily) that aren't set up yet. Please try a different assistant "
+                        "or contact your administrator."
+                    )
+
+                yield (f'data: {{"type":"error","content":"{error_message}"}}\n\n')
 
         return StreamingResponse(generate_response(), media_type="text/event-stream")
 

--- a/frontend/src/adapters/llamaStackAdapter.ts
+++ b/frontend/src/adapters/llamaStackAdapter.ts
@@ -62,13 +62,19 @@ export const LlamaStackParser: LlamaStackParserType = {
       // Handle errors
       if (json.type === 'error') {
         console.error('LlamaStack API error:', json.content);
-        return `[Error: ${json.content}]`;
+
+        return json.content;
       }
 
       return null;
     } catch (e) {
       // If we can't parse as JSON, return the raw line
-      console.warn('Failed to parse LlamaStack response:', e);
+      console.warn('Failed to parse LlamaStack response:', {
+        error: e,
+        rawLine: line,
+        lineLength: line.length,
+        lineType: typeof line,
+      });
       return null;
     }
   },

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -240,7 +240,7 @@ export function useChat(
           for (const line of lines) {
             if (line.startsWith('data: ')) {
               const data = line.slice(6).trim();
-              console.log('Received data line:', data); // Debug logging
+              if (import.meta.env.DEV) console.log('Received data line:', data); // Debug logging
 
               if (data === '[DONE]') {
                 // Stream finished


### PR DESCRIPTION
# Pull Request

## Description
Replaces the confusing error message "[Error: Received malformed response from server. Please try again.]" with a clear, actionable message when users try to chat with agents that need websearch tools.
Before: Generic server error that doesn't help users
After: "This assistant is not available right now. It needs internet search tools (such as Tavily) that aren't set up yet. Please try a different assistant or contact your administrator."

## Related Issue
<!-- [Link to Jira or GitHub issue](https://issues.redhat.com/browse/APPENG-3658) -->
Fixes #

## Type of Change
- [ ] Bug fix
- [ x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs update
- [ ] Tests

## Components Affected
- [ x] Frontend
- [ x] Backend
- [ ] Database
- [ ] Infrastructure

## Testing
<!-- How did you test your changes? -->
- [ ] Automated tests added/passing
- [ ] Manual testing done

## How Has This Been Tested?
<!--- What tests have you done to cover the implemented functionality -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if applicable)

## Additional Notes
<!-- Any additional information that reviewers should know -->
Is there any additional info that the reviewers should know?
