### PR TITLE
APPENG-3656 - MinIO doesn’t start up, which breaks the backend whenever ENABLE_ATTACHMENTS=true when using make dev-compose-up

### DIFF
--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -107,6 +107,9 @@ services:
         condition: service_healthy
       llamastack:
         condition: service_healthy
+      minio:
+        condition: service_healthy
+        required: false
     networks:
       - ai-va-network
     healthcheck:
@@ -154,6 +157,12 @@ services:
       - ai-va-network
     profiles:
       - attachments
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
 volumes:
   pgdata:


### PR DESCRIPTION
- Add health check configuration for MinIO service
- Add conditional dependency on MinIO for backend service
- Improve service startup reliability when attachments are enabled

🤖 Generated with [Claude Code](https://claude.ai/code)

# Pull Request

## Description
<!-- Briefly describe what this PR does -->

## Related Issue
<!-- Link to Jira or GitHub issue -->
Fixes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs update
- [ ] Tests

## Components Affected
- [ ] Frontend
- [ ] Backend
- [ ] Database
- [x] Infrastructure

## Testing
<!-- How did you test your changes? -->
- [ ] Automated tests added/passing
- [x] Manual testing done

## How Has This Been Tested?
<!--- What tests have you done to cover the implemented functionality -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if applicable)

## Additional Notes
<!-- Any additional information that reviewers should know -->
Is there any additional info that the reviewers should know?
