### PR TITLE
feat: allow model & tool selection prior to agent deployment

### DIFF
--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -138,6 +138,12 @@ services:
         condition: service_healthy
     networks:
       - ai-va-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5173 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
 
   # MinIO service for attachments (optional - use profile 'attachments')
   minio:

--- a/frontend/src/routes/_protected/_admin/config/agents.tsx
+++ b/frontend/src/routes/_protected/_admin/config/agents.tsx
@@ -238,7 +238,7 @@ function AgentTemplates() {
     return suiteDetailsMap?.[suiteId] || null;
   };
 
-  // When selectedTemplateIds changes, immediately populate templateOverrides with defaults
+  // When selectedTemplateIds changes, add defaults for newly selected templates (preserve existing overrides)
   useEffect(() => {
     if (selectedTemplateIds.length === 0) return;
 
@@ -301,10 +301,9 @@ function AgentTemplates() {
       });
   }, [selectedTemplateIds]);
 
-  // Reconcile template model with available models per spec:
-  // - If template model exists in the list, use it
-  // - Else if only one model available, use that one
-  // - Else force empty and require user selection
+  // Reconcile model selection:
+  // - If template model exists in the available list, preselect it
+  // - Otherwise leave empty and require user selection
   useEffect(() => {
     if (!models || models.length === 0) return;
     const available = new Set(models.map((m) => m.model_name));

--- a/frontend/src/services/models.ts
+++ b/frontend/src/services/models.ts
@@ -10,7 +10,7 @@ export const fetchModels = async (): Promise<Model[]> => {
   if (!response.ok) {
     throw new Error('Network response was not ok');
   }
-  const data: unknown = response.json();
+  const data: unknown = await response.json();
   return data as Model[];
 };
 
@@ -19,7 +19,7 @@ export const fetchEmbeddingModels = async (): Promise<EmbeddingModel[]> => {
   if (!response.ok) {
     throw new Error('Network response was not ok');
   }
-  const data: unknown = response.json();
+  const data: unknown = await response.json();
   return data as EmbeddingModel[];
 };
 

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -71,6 +71,9 @@ export interface TemplateInitializationRequest {
   custom_name?: string;
   custom_prompt?: string;
   include_knowledge_base?: boolean;
+  // Optional overrides when initializing from template
+  model_name?: string;
+  tools?: { toolgroup_id: string }[];
 }
 
 export interface TemplateInitializationResponse {


### PR DESCRIPTION
# Pull Request

## Description
<!-- Briefly describe what this PR does -->
Allow model & tool selection prior to agent deployment.

- Add pre-deploy config step for selected agents
- Fetch available models from API; preselect template model if present, otherwise require a choice
- Enable tool selection per-agent
- Apply chosen model/tool overrides to deployment payload
- Add validation and user-friendly errors on model API failures

## Related Issue
<!-- Link to Jira or GitHub issue -->
Fixes # [APPENG-3739](https://issues.redhat.com/browse/APPENG-3739)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs update
- [ ] Tests

## Components Affected
- [x] Frontend
- [x] Backend
- [ ] Database
- [ ] Infrastructure

## Testing
<!-- How did you test your changes? -->
- [ ] Automated tests added/passing
- [x] Manual testing done

## How Has This Been Tested?
<!--- What tests have you done to cover the implemented functionality -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Selected multiple agents → opened pre-deploy step → chose models/tools per agent → deployed → verified payloads contain correct overrides.
- Verified that cancelling clears temporary selections, and reopening starts fresh

## Screenshots/Videos (if applicable)
<img width="842" height="546" alt="image" src="https://github.com/user-attachments/assets/f7f76ee6-785d-47bf-afb9-cf3404a73682" />

## Additional Notes
<!-- Any additional information that reviewers should know -->
Is there any additional info that the reviewers should know?
No