### PR TITLE
fix agent templates to displace all knowledge bases

### DIFF
--- a/backend/app/api/v1/virtual_agents.py
+++ b/backend/app/api/v1/virtual_agents.py
@@ -29,16 +29,24 @@ async def create_virtual_agent_internal(
     va: VirtualAgentCreate,
     request: Request,
     db: AsyncSession,
+    skip_kb_validation: bool = False,
 ) -> VirtualAgentResponse:
     """
     Internal utility function to create a virtual agent.
     Can be used by API endpoints and other services without dependency injection issues.
+
+    Args:
+        va: Virtual agent configuration
+        request: HTTP request object for LlamaStack client
+        db: Database session
+        skip_kb_validation: If True, skip validation that KBs exist in LlamaStack.
+                           Useful when KBs are newly created and ingestion is pending.
     """
     agent_uuid = uuid.uuid4()
 
     # Validate knowledge bases and get vector store IDs if needed
     vector_store_ids = []
-    if va.knowledge_base_ids:
+    if va.knowledge_base_ids and not skip_kb_validation:
         vector_store_ids = await validate_and_get_vector_store_ids(
             va.knowledge_base_ids, request
         )

--- a/backend/app/schemas/agent_templates.py
+++ b/backend/app/schemas/agent_templates.py
@@ -25,7 +25,7 @@ class TemplateInitializationRequest(BaseModel):
     """Schema for template initialization request.
 
     Added optional override fields to allow callers (UI) to customize
-    the target model and tools before deploying from a template.
+    the target model, tools, and knowledge bases before deploying from a template.
     """
 
     template_name: str
@@ -36,6 +36,7 @@ class TemplateInitializationRequest(BaseModel):
     # Optional overrides
     model_name: Optional[str] = None
     tools: Optional[List[ToolAssociationInfo]] = None
+    knowledge_base_ids: Optional[List[str]] = None
 
 
 class TemplateInitializationResponse(BaseModel):

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -1,4 +1,5 @@
 import { ToolAssociationInfo } from './tools';
+import type { ReactNode } from 'react';
 
 export type SamplingStrategy = 'greedy' | 'top-p' | 'top-k';
 
@@ -73,6 +74,7 @@ export interface TemplateInitializationRequest {
   // Optional overrides when initializing from template
   model_name?: string;
   tools?: { toolgroup_id: string }[];
+  knowledge_base_ids?: string[];
 }
 
 export interface TemplateInitializationResponse {
@@ -90,7 +92,7 @@ export interface SuiteDetails {
   name: string;
   description: string;
   category: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   title: string;
   agents: string[];
   agentCount: number;


### PR DESCRIPTION
# Pull Request

## Description
This commit resolves two issues preventing knowledge bases from being properly linked to agents created from templates:

Problem 1: Incorrect field used for knowledge base IDs
- Previously used 'name' field (display name like "Commercial Banking Reference")
- Now correctly uses 'vector_store_name' (LlamaStack identifier like "commercial_banking_kb")

Problem 2: Timing issue with asynchronous ingestion pipeline
- Agent creation validated KB existence in LlamaStack immediately
- But ingestion pipeline creates vector stores asynchronously (takes time)
- Solution: Skip validation for newly created KBs via new skip_kb_validation parameter

The ingestion pipeline still needs to be fixed, @olavtar will open a PR to fix the ingestion pipeline chart version to `0.5.0` after this is merged in.

## Related Issue
<!-- Link to Jira or GitHub issue -->
Fixes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs update
- [ ] Tests

## Components Affected
- [x] Frontend
- [x] Backend
- [ ] Database
- [ ] Infrastructure

## Testing
<!-- How did you test your changes? -->
- [ ] Automated tests added/passing
- [x] Manual testing done

## How Has This Been Tested?
Deployed on dev02 cluster and tested the changes.

## Screenshots/Videos (if applicable)

## Additional Notes
<!-- Any additional information that reviewers should know -->
Is there any additional info that the reviewers should know?
