### PR TITLE
Refactor handling of MCP servers

### DIFF
--- a/backend/app/services/k8s_mcp_discovery.py
+++ b/backend/app/services/k8s_mcp_discovery.py
@@ -1,0 +1,224 @@
+"""Kubernetes MCP Server Discovery Service.
+
+This module discovers MCP servers deployed in Kubernetes by:
+1. Finding MCPServer custom resources with label app.kubernetes.io/component: mcp-server
+2. Finding Service resources with label app.kubernetes.io/component: mcp-server
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from kubernetes import client, config
+
+logger = logging.getLogger(__name__)
+
+
+class K8sMCPDiscovery:
+    """Discover MCP servers in Kubernetes."""
+
+    def __init__(self):
+        """Initialize Kubernetes client."""
+        try:
+            # Try to load in-cluster config first (when running in K8s)
+            config.load_incluster_config()
+            logger.info("Loaded in-cluster Kubernetes configuration")
+        except config.ConfigException:
+            try:
+                # Fall back to kubeconfig (for local development)
+                config.load_kube_config()
+                logger.info("Loaded kubeconfig Kubernetes configuration")
+            except config.ConfigException as e:
+                logger.warning(f"Could not load Kubernetes config: {e}")
+                self.enabled = False
+                return
+
+        self.enabled = True
+        self.custom_api = client.CustomObjectsApi()
+        self.core_api = client.CoreV1Api()
+
+        # Try to get namespace from service account mount first (in-cluster)
+        namespace_file = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+        if os.path.exists(namespace_file):
+            with open(namespace_file, "r") as f:
+                self.namespace = f.read().strip()
+        else:
+            # Fallback to environment variable or default
+            self.namespace = os.getenv("KUBERNETES_NAMESPACE", "default")
+
+        logger.info(f"Using Kubernetes namespace: {self.namespace}")
+
+    def discover_mcp_servers(self) -> List[Dict[str, Any]]:
+        """
+        Discover MCP servers from Kubernetes resources.
+
+        Returns:
+            List of discovered MCP servers with their metadata
+        """
+        if not self.enabled:
+            logger.warning("Kubernetes discovery is disabled")
+            return []
+
+        discovered_servers = []
+
+        # Discover MCPServer custom resources
+        try:
+            mcpserver_resources = self._discover_mcpserver_resources()
+            discovered_servers.extend(mcpserver_resources)
+            logger.info(f"Discovered {len(mcpserver_resources)} MCPServer resources")
+        except Exception as e:
+            logger.error(f"Error discovering MCPServer resources: {e}")
+
+        # Discover Service resources
+        try:
+            service_resources = self._discover_service_resources()
+            discovered_servers.extend(service_resources)
+            logger.info(f"Discovered {len(service_resources)} Service resources")
+        except Exception as e:
+            logger.error(f"Error discovering Service resources: {e}")
+
+        return discovered_servers
+
+    def _discover_mcpserver_resources(self) -> List[Dict[str, Any]]:
+        """
+        Discover MCPServer custom resources.
+
+        Returns:
+            List of discovered MCPServer resources
+        """
+        discovered = []
+        label_selector = "app.kubernetes.io/component=mcp-server"
+
+        try:
+            # List MCPServer resources in the namespace
+            resources = self.custom_api.list_namespaced_custom_object(
+                group="toolhive.stacklok.dev",
+                version="v1alpha1",
+                namespace=self.namespace,
+                plural="mcpservers",
+                label_selector=label_selector,
+            )
+
+            for item in resources.get("items", []):
+                metadata = item.get("metadata", {})
+                spec = item.get("spec", {})
+                status = item.get("status", {})
+
+                name = metadata.get("name", "")
+                description = spec.get("description", "")
+                # Auto-generate description if empty
+                if not description:
+                    description = (
+                        f"MCP server discovered from mcpserver resource '{name}'"
+                    )
+                proxy_mode = spec.get("proxyMode", "")
+
+                # Get URL from status
+                endpoint_url = self._get_mcpserver_url(status, proxy_mode)
+
+                if endpoint_url:
+                    discovered.append(
+                        {
+                            "source": "mcpserver",
+                            "name": name,
+                            "description": description,
+                            "endpoint_url": endpoint_url,
+                        }
+                    )
+
+        except client.exceptions.ApiException as e:
+            if e.status == 404:
+                logger.info("MCPServer CRD not found in cluster")
+            else:
+                logger.error(f"Error listing MCPServer resources: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error discovering MCPServer resources: {e}")
+
+        return discovered
+
+    def _get_mcpserver_url(
+        self, status: Dict[str, Any], proxy_mode: str
+    ) -> Optional[str]:
+        """
+        Extract URL from MCPServer status.
+
+        Args:
+            status: MCPServer status object
+            proxy_mode: Proxy mode from spec
+
+        Returns:
+            Constructed endpoint URL or None
+        """
+        base_url = status.get("url")
+
+        if not base_url:
+            return None
+
+        if proxy_mode == "streamable-http":
+            # Append /mcp for streamable-http mode
+            return f"{base_url}/mcp"
+        else:
+            # Append /sse for other modes
+            return f"{base_url}/sse"
+
+    def _discover_service_resources(self) -> List[Dict[str, Any]]:
+        """
+        Discover Service resources with MCP server label.
+
+        Returns:
+            List of discovered Service resources
+        """
+        discovered = []
+        label_selector = "app.kubernetes.io/component=mcp-server"
+
+        try:
+            # List Services in the namespace
+            services = self.core_api.list_namespaced_service(
+                namespace=self.namespace, label_selector=label_selector
+            )
+
+            for service in services.items:
+                name = service.metadata.name
+
+                # Get service description from annotation
+                annotations = service.metadata.annotations or {}
+                description = annotations.get("description", "")
+                # Auto-generate description if empty
+                if not description:
+                    description = (
+                        f"MCP server discovered from service resource '{name}'"
+                    )
+
+                # Get first port
+                if service.spec.ports:
+                    port = service.spec.ports[0].port
+                    # Construct service URL
+                    endpoint_url = (
+                        f"http://{name}.{self.namespace}.svc.cluster.local:{port}/sse"
+                    )
+
+                    discovered.append(
+                        {
+                            "source": "service",
+                            "name": name,
+                            "description": description,
+                            "endpoint_url": endpoint_url,
+                        }
+                    )
+
+        except Exception as e:
+            logger.error(f"Error discovering Service resources: {e}")
+
+        return discovered
+
+
+# Singleton instance
+_discovery_instance: Optional[K8sMCPDiscovery] = None
+
+
+def get_k8s_discovery() -> K8sMCPDiscovery:
+    """Get singleton K8sMCPDiscovery instance."""
+    global _discovery_instance
+    if _discovery_instance is None:
+        _discovery_instance = K8sMCPDiscovery()
+    return _discovery_instance

--- a/deploy/cluster/helm/templates/rbac.yaml
+++ b/deploy/cluster/helm/templates/rbac.yaml
@@ -9,6 +9,14 @@ rules:
   resources:
   - secrets
   - endpoints
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - toolhive.stacklok.dev
+  resources:
+  - mcpservers
   verbs:
   - get
   - list

--- a/frontend/src/components/MCPServerCard.tsx
+++ b/frontend/src/components/MCPServerCard.tsx
@@ -18,6 +18,7 @@ import {
   ModalFooter,
   Button,
   Icon,
+  Alert,
 } from '@patternfly/react-core';
 import { EllipsisVIcon, TrashIcon, EditIcon } from '@patternfly/react-icons';
 import { useState, Fragment } from 'react';
@@ -28,6 +29,8 @@ interface MCPServerCardProps {
   onDelete?: (toolgroup_id: string) => void;
   onEdit?: (mcpServer: MCPServer) => void;
   isDeleting?: boolean;
+  deleteError?: Error | null;
+  resetDeleteError?: () => void;
 }
 
 export function MCPServerCard({
@@ -35,6 +38,8 @@ export function MCPServerCard({
   onDelete,
   onEdit,
   isDeleting = false,
+  deleteError,
+  resetDeleteError,
 }: MCPServerCardProps) {
   const [dropdownOpen, setDropdownOpen] = useState<boolean>(false);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
@@ -43,6 +48,10 @@ export function MCPServerCard({
   const onExpand = () => setIsExpanded(!isExpanded);
 
   const toggleModal = () => {
+    if (modalOpen && resetDeleteError) {
+      // Clear error when closing modal
+      resetDeleteError();
+    }
     setModalOpen(!modalOpen);
   };
 
@@ -111,16 +120,24 @@ export function MCPServerCard({
       >
         <ModalHeader title="Delete MCP Server" labelId="delete-mcp-modal-title" />
         <ModalBody id="delete-mcp-modal-desc">
-          Are you sure you want to delete this MCP server? This action cannot be undone.
+          {deleteError ? (
+            <Alert variant="danger" title="Error deleting MCP server" isInline>
+              {deleteError.message}
+            </Alert>
+          ) : (
+            'Are you sure you want to delete this MCP server? This action cannot be undone.'
+          )}
         </ModalBody>
-        <ModalFooter>
-          <Button isLoading={isDeleting} onClick={handleDeleteServer} variant="danger">
-            Delete
-          </Button>
-          <Button variant="link" onClick={toggleModal}>
-            Cancel
-          </Button>
-        </ModalFooter>
+        {!deleteError && (
+          <ModalFooter>
+            <Button isLoading={isDeleting} onClick={handleDeleteServer} variant="danger">
+              Delete
+            </Button>
+            <Button variant="link" onClick={toggleModal}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        )}
       </Modal>
     </Fragment>
   );

--- a/frontend/src/components/MCPServerForm.tsx
+++ b/frontend/src/components/MCPServerForm.tsx
@@ -1,4 +1,5 @@
 import { useForm } from '@tanstack/react-form';
+import { useEffect } from 'react';
 import { MCPServer, MCPServerCreate } from '@/types';
 import {
   Button,
@@ -17,6 +18,7 @@ interface MCPServerFormProps {
   onSubmit: (values: MCPServerCreate) => void;
   onCancel: () => void;
   error?: Error | null;
+  isEditing?: boolean; // True when editing existing server, false when creating new
 }
 
 export function MCPServerForm({
@@ -25,6 +27,7 @@ export function MCPServerForm({
   onSubmit,
   onCancel,
   error,
+  isEditing = false,
 }: MCPServerFormProps) {
   const initialData: MCPServerCreate = defaultServer
     ? {
@@ -64,6 +67,28 @@ export function MCPServerForm({
     },
   });
 
+  // Reset form when defaultServer changes (e.g., when selecting a different discovered server)
+  useEffect(() => {
+    if (defaultServer) {
+      const newData: MCPServerCreate = {
+        toolgroup_id: defaultServer.toolgroup_id,
+        name: defaultServer.name,
+        description: defaultServer.description || '',
+        endpoint_url: defaultServer.endpoint_url,
+        configuration: defaultServer.configuration || {},
+      };
+
+      form.reset();
+      // Set values without triggering validation
+      (
+        Object.entries(newData) as [keyof MCPServerCreate, string | Record<string, unknown>][]
+      ).forEach(([key, value]) => {
+        form.setFieldValue(key, value);
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultServer]);
+
   return (
     <Form
       onSubmit={(e) => {
@@ -74,7 +99,78 @@ export function MCPServerForm({
     >
       {error && <Alert variant="danger" title={error.message} />}
 
-      {/* NEW: Toolgroup ID field */}
+      {/* Name field - FIRST */}
+      <form.Field
+        name="name"
+        validators={{
+          onChange: ({ value }) => (!value ? 'Name is required' : undefined),
+        }}
+      >
+        {(field) => (
+          <FormGroup label="Name" isRequired fieldId="mcp-form-name">
+            <TextInput
+              isRequired
+              id="mcp-form-name"
+              value={field.state.value}
+              onChange={(_e, v) => {
+                field.handleChange(v);
+                // Auto-fill toolgroup_id as "mcp::" + name (only if not editing)
+                if (!isEditing) {
+                  form.setFieldValue('toolgroup_id', `mcp::${v}`);
+                }
+              }}
+              validated={
+                !field.state.meta.isTouched
+                  ? 'default'
+                  : field.state.meta.errors.length > 0
+                    ? 'error'
+                    : 'success'
+              }
+              placeholder="Enter MCP server name"
+              isDisabled={isEditing} // Disable when editing to keep name and toolgroup_id consistent
+            />
+            {field.state.meta.errors.length > 0 && (
+              <div style={{ color: '#c9190b', fontSize: '14px', marginTop: '4px' }}>
+                {field.state.meta.errors[0]}
+              </div>
+            )}
+          </FormGroup>
+        )}
+      </form.Field>
+
+      {/* Description field - SECOND */}
+      <form.Field
+        name="description"
+        validators={{
+          onChange: ({ value }) => (!value ? 'Description is required' : undefined),
+        }}
+      >
+        {(field) => (
+          <FormGroup label="Description" isRequired fieldId="mcp-form-description">
+            <TextInput
+              isRequired
+              id="mcp-form-description"
+              value={field.state.value || ''}
+              onChange={(_e, v) => field.handleChange(v)}
+              placeholder="Enter description"
+              validated={
+                !field.state.meta.isTouched
+                  ? 'default'
+                  : field.state.meta.errors.length > 0
+                    ? 'error'
+                    : 'success'
+              }
+            />
+            {field.state.meta.errors.length > 0 && (
+              <div style={{ color: '#c9190b', fontSize: '14px', marginTop: '4px' }}>
+                {field.state.meta.errors[0]}
+              </div>
+            )}
+          </FormGroup>
+        )}
+      </form.Field>
+
+      {/* Toolgroup ID field - THIRD (auto-filled from name) */}
       <form.Field
         name="toolgroup_id"
         validators={{
@@ -97,72 +193,6 @@ export function MCPServerForm({
               }
               placeholder="mcp::my_server"
               isDisabled={!!defaultServer} // Disable editing for existing servers
-            />
-            {field.state.meta.errors.length > 0 && (
-              <div style={{ color: '#c9190b', fontSize: '14px', marginTop: '4px' }}>
-                {field.state.meta.errors[0]}
-              </div>
-            )}
-            <div style={{ fontSize: '14px', color: '#6a6e73', marginTop: '4px' }}>
-              Unique identifier for this MCP server (e.g., mcp::my_server)
-            </div>
-          </FormGroup>
-        )}
-      </form.Field>
-
-      <form.Field
-        name="name"
-        validators={{
-          onChange: ({ value }) => (!value ? 'Name is required' : undefined),
-        }}
-      >
-        {(field) => (
-          <FormGroup label="Name" isRequired fieldId="mcp-form-name">
-            <TextInput
-              isRequired
-              id="mcp-form-name"
-              value={field.state.value}
-              onChange={(_e, v) => field.handleChange(v)}
-              validated={
-                !field.state.meta.isTouched
-                  ? 'default'
-                  : field.state.meta.errors.length > 0
-                    ? 'error'
-                    : 'success'
-              }
-              placeholder="Enter MCP server name"
-            />
-            {field.state.meta.errors.length > 0 && (
-              <div style={{ color: '#c9190b', fontSize: '14px', marginTop: '4px' }}>
-                {field.state.meta.errors[0]}
-              </div>
-            )}
-          </FormGroup>
-        )}
-      </form.Field>
-
-      {/* Description now required in the new schema */}
-      <form.Field
-        name="description"
-        validators={{
-          onChange: ({ value }) => (!value ? 'Description is required' : undefined),
-        }}
-      >
-        {(field) => (
-          <FormGroup label="Description" isRequired fieldId="mcp-form-description">
-            <TextInput
-              isRequired
-              id="mcp-form-description"
-              value={field.state.value || ''}
-              onChange={(_e, v) => field.handleChange(v)}
-              placeholder="Enter description"
-              validated={
-                !field.state.meta.isTouched
-                  ? 'default'
-                  : field.state.meta.errors.length > 0
-                    ? 'error'
-                    : 'success'
-              }
             />
             {field.state.meta.errors.length > 0 && (
               <div style={{ color: '#c9190b', fontSize: '14px', marginTop: '4px' }}>
@@ -288,7 +318,7 @@ export function MCPServerForm({
                 isDisabled={Boolean(shouldDisable)}
                 isLoading={Boolean(isSubmitting || isSubmittingForm)}
               >
-                {defaultServer ? 'Update' : 'Create'}
+                {isEditing ? 'Update' : 'Create'}
               </Button>
             );
           }}

--- a/frontend/src/components/MCPServerList.tsx
+++ b/frontend/src/components/MCPServerList.tsx
@@ -19,6 +19,8 @@ export function MCPServerList() {
     error: serversError,
     deleteMCPServer,
     isDeleting,
+    deleteError,
+    resetDeleteError,
     refreshMCPServers,
   } = useMCPServers();
 
@@ -106,6 +108,7 @@ export function MCPServerList() {
           mcpServers.length > 0 &&
           mcpServers
             .sort((a, b) => Date.parse(b.created_at ?? '') - Date.parse(a.created_at ?? ''))
+            .filter((server) => server.toolgroup_id !== editingServer?.toolgroup_id)
             .map((server) => (
               <MCPServerCard
                 key={server.toolgroup_id}
@@ -113,6 +116,8 @@ export function MCPServerList() {
                 onDelete={handleDeleteServer}
                 onEdit={handleEditServer}
                 isDeleting={isDeleting}
+                deleteError={deleteError}
+                resetDeleteError={resetDeleteError}
               />
             ))}
         {!isLoadingServers && !serversError && mcpServers && mcpServers.length === 0 && (

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,7 +1,7 @@
 // Export all custom hooks
 export { useAgents } from './useAgents';
 export { useKnowledgeBases } from './useKnowledgeBases';
-export { useMCPServers } from './useMCPServers';
+export { useMCPServers, useDiscoveredMCPServers } from './useMCPServers';
 export { useModels } from './useModels';
 export { useTools } from './useTools';
 export { useShields } from './useShields';

--- a/frontend/src/hooks/useMCPServers.ts
+++ b/frontend/src/hooks/useMCPServers.ts
@@ -1,11 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { MCPServer, MCPServerCreate } from '@/types';
+import { MCPServer, MCPServerCreate, DiscoveredMCPServer } from '@/types';
 import {
   fetchMCPServers,
   createMCPServer,
   updateMCPServer,
   deleteMCPServer,
   syncMCPServers,
+  discoverMCPServers,
 } from '@/services/mcp-servers';
 
 export const useMCPServers = () => {
@@ -22,6 +23,7 @@ export const useMCPServers = () => {
     mutationFn: createMCPServer,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['mcpServers'] });
+      void queryClient.invalidateQueries({ queryKey: ['tools'] }); // MCP servers are toolgroups
     },
     onError: (error) => {
       console.error('Failed to create MCP server:', error);
@@ -37,6 +39,7 @@ export const useMCPServers = () => {
     mutationFn: ({ toolgroup_id, serverUpdate }) => updateMCPServer(toolgroup_id, serverUpdate),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['mcpServers'] });
+      void queryClient.invalidateQueries({ queryKey: ['tools'] }); // MCP servers are toolgroups
     },
     onError: (error) => {
       console.error('Failed to update MCP server:', error);
@@ -48,6 +51,7 @@ export const useMCPServers = () => {
     mutationFn: deleteMCPServer,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['mcpServers'] });
+      void queryClient.invalidateQueries({ queryKey: ['tools'] }); // MCP servers are toolgroups
     },
     onError: (error) => {
       console.error('Failed to delete MCP server:', error);
@@ -59,6 +63,7 @@ export const useMCPServers = () => {
     mutationFn: syncMCPServers,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['mcpServers'] });
+      void queryClient.invalidateQueries({ queryKey: ['tools'] }); // MCP servers are toolgroups
     },
     onError: (error) => {
       console.error('Failed to sync MCP servers:', error);
@@ -68,6 +73,7 @@ export const useMCPServers = () => {
   // Helper function to refresh MCP servers
   const refreshMCPServers = () => {
     void queryClient.invalidateQueries({ queryKey: ['mcpServers'] });
+    void queryClient.invalidateQueries({ queryKey: ['tools'] }); // MCP servers are toolgroups
   };
 
   return {
@@ -93,7 +99,27 @@ export const useMCPServers = () => {
     deleteError: deleteMCPServerMutation.error,
     syncError: syncMCPServersMutation.error,
 
+    // Mutation resets
+    resetCreateError: createMCPServerMutation.reset,
+    resetUpdateError: updateMCPServerMutation.reset,
+    resetDeleteError: deleteMCPServerMutation.reset,
+
     // Utilities
     refreshMCPServers,
+  };
+};
+
+export const useDiscoveredMCPServers = (enabled: boolean = true) => {
+  const discoveredServersQuery = useQuery<DiscoveredMCPServer[], Error>({
+    queryKey: ['discoveredMCPServers'],
+    queryFn: discoverMCPServers,
+    enabled,
+  });
+
+  return {
+    discoveredServers: discoveredServersQuery.data,
+    isDiscovering: discoveredServersQuery.isLoading,
+    discoverError: discoveredServersQuery.error,
+    refetchDiscovered: discoveredServersQuery.refetch,
   };
 };

--- a/frontend/src/services/mcp-servers.ts
+++ b/frontend/src/services/mcp-servers.ts
@@ -1,10 +1,17 @@
 import { MCP_SERVERS_API_ENDPOINT } from '@/config/api';
-import { MCPServer, MCPServerCreate } from '@/types';
+import { MCPServer, MCPServerCreate, DiscoveredMCPServer } from '@/types';
+
+interface ErrorResponse {
+  detail?: string;
+}
 
 export const fetchMCPServers = async (): Promise<MCPServer[]> => {
   const response = await fetch(MCP_SERVERS_API_ENDPOINT);
   if (!response.ok) {
-    throw new Error('Network response was not ok');
+    const errorData = (await response
+      .json()
+      .catch(() => ({ detail: 'Network response was not ok' }))) as ErrorResponse;
+    throw new Error(errorData.detail ?? 'Network response was not ok');
   }
   const data: unknown = await response.json();
   return data as MCPServer[];
@@ -19,7 +26,10 @@ export const createMCPServer = async (newServer: MCPServerCreate): Promise<MCPSe
     body: JSON.stringify(newServer),
   });
   if (!response.ok) {
-    throw new Error('Network response was not ok');
+    const errorData = (await response
+      .json()
+      .catch(() => ({ detail: 'Network response was not ok' }))) as ErrorResponse;
+    throw new Error(errorData.detail ?? 'Network response was not ok');
   }
   const data: unknown = await response.json();
   return data as MCPServer;
@@ -37,7 +47,10 @@ export const updateMCPServer = async (
     body: JSON.stringify(serverUpdate),
   });
   if (!response.ok) {
-    throw new Error('Network response was not ok');
+    const errorData = (await response
+      .json()
+      .catch(() => ({ detail: 'Network response was not ok' }))) as ErrorResponse;
+    throw new Error(errorData.detail ?? 'Network response was not ok');
   }
   const data: unknown = await response.json();
   return data as MCPServer;
@@ -48,7 +61,10 @@ export const deleteMCPServer = async (toolgroup_id: string): Promise<void> => {
     method: 'DELETE',
   });
   if (!response.ok) {
-    throw new Error('Network response was not ok');
+    const errorData = (await response
+      .json()
+      .catch(() => ({ detail: 'Network response was not ok' }))) as ErrorResponse;
+    throw new Error(errorData.detail ?? 'Network response was not ok');
   }
   return;
 };
@@ -58,8 +74,23 @@ export const syncMCPServers = async (): Promise<MCPServer[]> => {
     method: 'POST',
   });
   if (!response.ok) {
-    throw new Error('Network response was not ok');
+    const errorData = (await response
+      .json()
+      .catch(() => ({ detail: 'Network response was not ok' }))) as ErrorResponse;
+    throw new Error(errorData.detail ?? 'Network response was not ok');
   }
   const data: unknown = await response.json();
   return data as MCPServer[];
+};
+
+export const discoverMCPServers = async (): Promise<DiscoveredMCPServer[]> => {
+  const response = await fetch(MCP_SERVERS_API_ENDPOINT + 'discover');
+  if (!response.ok) {
+    const errorData = (await response
+      .json()
+      .catch(() => ({ detail: 'Failed to discover MCP servers' }))) as ErrorResponse;
+    throw new Error(errorData.detail ?? 'Failed to discover MCP servers');
+  }
+  const data: unknown = await response.json();
+  return data as DiscoveredMCPServer[];
 };

--- a/frontend/src/types/tools.ts
+++ b/frontend/src/types/tools.ts
@@ -34,3 +34,10 @@ export type Tool = ToolGroup;
 export interface ToolAssociationInfo {
   toolgroup_id: string;
 }
+
+export interface DiscoveredMCPServer {
+  source: 'mcpserver' | 'service';
+  name: string;
+  description: string;
+  endpoint_url: string;
+}


### PR DESCRIPTION
- Add K8s-based discovery for MCPServer CRs and Services
- Fix description field persistence (was overwritten by config)
- Prevent duplicate MCP servers (409 conflict)
- Prevent deletion when MCP server in use by agents
- Fix update endpoint (unregister then re-register)
- Auto-generate toolgroup_id as mcp::{name}
- Improve error handling with detailed messages


Assisted-by: Claude

# Pull Request

## Description
<!-- Briefly describe what this PR does -->

## Related Issue
<!-- Link to Jira or GitHub issue -->
Fixes #

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs update
- [ ] Tests

## Components Affected
- [x] Frontend
- [x] Backend
- [ ] Database
- [ ] Infrastructure

## Testing
<!-- How did you test your changes? -->
- [ ] Automated tests added/passing
- [x] Manual testing done

## How Has This Been Tested?
<!--- What tests have you done to cover the implemented functionality -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if applicable)

## Additional Notes
<!-- Any additional information that reviewers should know -->
Is there any additional info that the reviewers should know?
