### PR TITLE
Bump llamastack chart to 0.6.8

### DIFF
--- a/deploy/cluster/helm/Chart.lock
+++ b/deploy/cluster/helm/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.5.7
 - name: llama-stack
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.6.4
+  version: 0.6.8
 - name: configure-pipeline
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.5
@@ -20,5 +20,5 @@ dependencies:
 - name: oracle-db
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.3
-digest: sha256:4eaa4dbc08ea023cb619318ccaca964382f734fa8c4b3d20a02797cc755b0792
-generated: "2025-12-04T09:30:40.467411067-05:00"
+digest: sha256:bafaf64a5426b7db12c3f03bceb690a24b9e9fe4eb57f7e8f0f193351a448c55
+generated: "2026-01-20T11:12:27.86582992-05:00"

--- a/deploy/cluster/helm/Chart.yaml
+++ b/deploy/cluster/helm/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     version: 0.5.7
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: llama-stack
-    version: 0.6.4
+    version: 0.6.8
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: configure-pipeline
     version: 0.5.5


### PR DESCRIPTION
# Pull Request

## Description
<!-- Briefly describe what this PR does -->
Bumps llamastack chart to 0.6.8 that supports empty list of models for use with VertexAI

## Related Issue
<!-- Link to Jira or GitHub issue -->
Fixes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs update
- [ ] Tests

## Components Affected
- [ ] Frontend
- [ ] Backend
- [ ] Database
- [ ] Infrastructure

## Testing
<!-- How did you test your changes? -->
- [ ] Automated tests added/passing
- [ ] Manual testing done

## How Has This Been Tested?
<!--- What tests have you done to cover the implemented functionality -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if applicable)

## Additional Notes
<!-- Any additional information that reviewers should know -->
Is there any additional info that the reviewers should know?
