### PR TITLE
feat: make model_name optional in agent templates to support user-selected models

### DIFF
--- a/backend/agent_templates/core_banking.yaml
+++ b/backend/agent_templates/core_banking.yaml
@@ -6,7 +6,7 @@ templates:
     name: "Customer Service Assistant"
     persona: "customer_service"
     prompt: "You are a Customer Service Assistant for branch tellers and customer service representatives. You help with day-to-day customer queries about product fees, account policies, transaction processing, and regulatory timelines. You provide accurate information about bank products and services."
-    model_name: "meta-llama/Llama-3.1-8B-Instruct"
+    # model_name is optional - user will select from registered models
     tools:
       - toolgroup_id: "builtin::websearch"
     knowledge_base_ids: []

--- a/backend/app/api/v1/agent_templates.py
+++ b/backend/app/api/v1/agent_templates.py
@@ -331,19 +331,27 @@ async def initialize_agent_from_template(
         if kb_ids and not any(tool.toolgroup_id == "builtin::rag" for tool in tools):
             tools.append(ToolAssociationInfo(toolgroup_id="builtin::rag"))
 
-        # Determine model: in local dev use DEFAULT_INFERENCE_MODEL so template
-        # agents work with Ollama/LlamaStack dev stack; otherwise use request or
-        # template model.
+        # Determine model: priority order:
+        # 1. User-selected model from request (highest priority)
+        # 2. Local dev DEFAULT_INFERENCE_MODEL (for dev convenience)
+        # 3. Template's model_name (YAML default, if specified)
+        # 4. Error if none provided
         if request.model_name:
             model_to_use = request.model_name
         elif is_local_dev_mode() and settings.DEFAULT_INFERENCE_MODEL:
             model_to_use = settings.DEFAULT_INFERENCE_MODEL
             logger.info(
                 f"Local dev: using DEFAULT_INFERENCE_MODEL={model_to_use} "
-                f"instead of template model '{template.model_name}'"
+                f"(template model: {template.model_name or 'not specified'})"
             )
-        else:
+        elif template.model_name:
             model_to_use = template.model_name
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"No model specified for template '{request.template_name}'. "
+                "Please select a model from the registered models.",
+            )
 
         agent_config = VirtualAgentCreate(
             name=agent_name,

--- a/backend/app/core/template_loader.py
+++ b/backend/app/core/template_loader.py
@@ -60,7 +60,7 @@ def convert_yaml_template_to_agent_template(
         name=yaml_template["name"],
         persona=yaml_template["persona"],
         prompt=yaml_template["prompt"],
-        model_name=yaml_template["model_name"],
+        model_name=yaml_template.get("model_name"),  # Optional - can be None
         runner_type=yaml_template.get("runner_type", "llamastack"),
         tools=yaml_template.get("tools") or [],
         knowledge_base_ids=yaml_template.get("knowledge_base_ids") or [],

--- a/backend/app/schemas/agent_templates.py
+++ b/backend/app/schemas/agent_templates.py
@@ -14,7 +14,7 @@ class AgentTemplate(BaseModel):
     name: str
     persona: str
     prompt: str
-    model_name: str
+    model_name: Optional[str] = None  # Optional - can be specified in YAML or selected by user
     runner_type: str = "llamastack"
     tools: List[Dict[str, str]]
     knowledge_base_ids: List[str]

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -54,7 +54,7 @@ export interface AgentTemplate {
   name: string;
   persona: string;
   prompt: string;
-  model_name: string;
+  model_name?: string;  // Optional - can be specified in template or selected by user
   tools: Array<{ toolgroup_id: string }>;
   knowledge_base_ids: string[];
   knowledge_base_config?: {


### PR DESCRIPTION
# Pull Request

## Description
Allow users to configure which model to use when deploying agent templates based on registered models in the system, rather than requiring pre-defined models in YAML files.

Changes:
- Made model_name optional in AgentTemplate schema (backend and frontend)
- Updated template initialization logic with priority order:
  1. User-selected model from request
  2. Local dev DEFAULT_INFERENCE_MODEL
  3. Template's model_name (if specified)
  4. Error if none provided
- Updated template loader to handle optional model_name
- Added example in core_banking.yaml showing template without model_name

This allows template authors to either suggest a default model or omit it entirely, while giving users full control to select from registered models.

## Related Issue
Fixes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs update
- [ ] Tests

## Components Affected
- [ ] Frontend
- [x] Backend
- [ ] Database
- [ ] Infrastructure

## Testing
<!-- How did you test your changes? -->
- [ ] Automated tests added/passing
- [x] Manual testing done

## How Has This Been Tested?
<!--- What tests have you done to cover the implemented functionality -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if applicable)

## Additional Notes
<!-- Any additional information that reviewers should know -->
Is there any additional info that the reviewers should know?
