### PR TITLE
Update llama-stack to 0.6.1 for Docker Hub migration

### DIFF
--- a/backend/app/api/v1/chat_sessions.py
+++ b/backend/app/api/v1/chat_sessions.py
@@ -285,13 +285,11 @@ async def get_conversation_messages(
         client = get_client_from_request(request)
         try:
             # List items in the conversation
-            # The include parameter is required (empty list to get default fields)
+            # The include parameter is optional - omit it to get default fields
             # Available include values are for extra fields like:
             # "file_search_call.results", "reasoning.encrypted_content", etc.
             items_response = await client.conversations.items.list(
                 conversation_id=session.conversation_id,
-                after=None,
-                include=[],
                 limit=100,
                 order="asc",
             )

--- a/backend/app/api/v1/llama_stack.py
+++ b/backend/app/api/v1/llama_stack.py
@@ -15,6 +15,33 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# Version-independent helpers for llama-stack API changes
+def _get_model_type(model):
+    """Get model type from various API versions (api_model_type in 0.3.x, model_type in 0.6.1)"""
+    for attr in ("api_model_type", "model_type"):
+        val = getattr(model, attr, None)
+        if val is not None:
+            return val
+    meta = getattr(model, "custom_metadata", None) or {}
+    return meta.get("model_type")
+
+
+def _get_model_id(model):
+    """Get model ID from various API versions (identifier in 0.3.x, id in 0.6.1)"""
+    return getattr(model, "identifier", None) or getattr(model, "id", "unknown")
+
+
+def _get_provider_resource_id(model):
+    """Get provider_resource_id from various API versions (direct attribute in 0.3.x, custom_metadata in 0.6.1)"""
+    # Try direct attribute first (0.3.x)
+    val = getattr(model, "provider_resource_id", None)
+    if val is not None:
+        return str(val)
+    # Fall back to custom_metadata (0.6.1)
+    meta = getattr(model, "custom_metadata", None) or {}
+    return str(meta.get("provider_resource_id", "unknown"))
+
+
 def _build_env_default_entry() -> Dict[str, Any] | None:
     """Return an env-default model entry when any runner default is configured."""
     configured = []
@@ -48,7 +75,7 @@ async def get_llms(request: Request):
     try:
         logger.info(f"Attempting to fetch models from LlamaStack at {client.base_url}")
         try:
-            models = await client.models.list()
+            models = list(await client.models.list())
             logger.info(f"Received response from LlamaStack: {models}")
         except Exception as client_error:
             logger.error(f"Error calling LlamaStack API: {str(client_error)}")
@@ -83,9 +110,9 @@ async def get_llms(request: Request):
 
         for model in models:
             try:
-                if model.api_model_type == "llm":
-                    provider_resource_id = str(model.provider_resource_id)
-                    model_id = str(model.identifier)
+                if _get_model_type(model) == "llm":
+                    provider_resource_id = _get_provider_resource_id(model)
+                    model_id = _get_model_id(model)
 
                     if (
                         provider_resource_id in shield_resource_ids
@@ -94,9 +121,9 @@ async def get_llms(request: Request):
                         continue
 
                     llm_config = {
-                        "model_name": str(model.identifier),
-                        "provider_resource_id": model.provider_resource_id,
-                        "model_type": model.api_model_type,
+                        "model_name": _get_model_id(model),
+                        "provider_resource_id": _get_provider_resource_id(model),
+                        "model_type": _get_model_type(model),
                     }
                     llms.append(llm_config)
             except AttributeError as ae:
@@ -146,7 +173,7 @@ async def get_safety_models(request: Request):
     """
     client = get_client_from_request(request)
     try:
-        models = await client.models.list()
+        models = list(await client.models.list())
         safety_models = []
         for model in models:
             if model.model_type == "safety":
@@ -168,7 +195,7 @@ async def get_embedding_models(request: Request):
     """
     client = get_client_from_request(request)
     try:
-        models = await client.models.list()
+        models = list(await client.models.list())
         embedding_models = []
         for model in models:
             if model.model_type == "embedding":

--- a/backend/app/api/v1/models_management.py
+++ b/backend/app/api/v1/models_management.py
@@ -64,7 +64,7 @@ async def list_models(request: Request):
     client = get_client_from_request(request)
     try:
         # Fetch models and shields in parallel
-        models = await client.models.list()
+        models = list(await client.models.list())
 
         # Fetch shields and create a set of shield resource IDs for efficient lookup
         shield_resource_ids = set()

--- a/backend/app/services/runners/llamastack_runner.py
+++ b/backend/app/services/runners/llamastack_runner.py
@@ -630,8 +630,14 @@ class LlamaStackRunner(BaseRunner):
 
                 if is_local_dev_mode():
                     try:
-                        models_list = await client.models.list()
-                        available_ids = [str(m.identifier) for m in models_list]
+                        models_list = list(await client.models.list())
+                        available_ids = [
+                            str(
+                                getattr(m, "identifier", None)
+                                or getattr(m, "id", "unknown")
+                            )
+                            for m in models_list
+                        ]
                         if (
                             available_ids
                             and response_params["model"] not in available_ids

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,8 +8,8 @@ pydantic
 python-dotenv
 bcrypt
 pydantic[email]
-llama-stack==0.3.5
-llama_stack_client==0.3.5
+llama-stack==0.6.1
+llama_stack_client==0.6.1
 fire
 httpx
 kubernetes

--- a/deploy/cluster/helm/Chart.lock
+++ b/deploy/cluster/helm/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.5.9
 - name: llama-stack
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.6.10
+  version: 0.8.6
 - name: configure-pipeline
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.6
@@ -20,5 +20,5 @@ dependencies:
 - name: oracle-db
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.5
-digest: sha256:54e260a78f2c308672bf60e4c379c07a9195251b5580037018fc5a163b4acb3d
-generated: "2026-02-11T11:00:15.772779627-05:00"
+digest: sha256:929fc3fa16d5b7fb37ba194edb29bbdda3e8fd98e6f9eda37c36ffd6653ae901
+generated: "2026-06-22T15:15:22.002701642-04:00"

--- a/deploy/cluster/helm/Chart.yaml
+++ b/deploy/cluster/helm/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     version: 0.5.9
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: llama-stack
-    version: 0.6.10
+    version: 0.8.6
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: configure-pipeline
     version: 0.5.6

--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -64,7 +64,7 @@ services:
 
   # LlamaStack service
   llamastack:
-    image: llamastack/distribution-starter:0.3.2
+    image: docker.io/ogxai/distribution-starter:0.6.1
     container_name: llamastack-dev
     platform: linux/amd64
     restart: unless-stopped
@@ -83,11 +83,11 @@ services:
     networks:
       - ai-va-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8321/docs || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:8321/v1/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 30
-      start_period: 60s
+      start_period: 90s
     depends_on:
       ollama:
         condition: service_healthy

--- a/deploy/local/llamastack-run.yaml
+++ b/deploy/local/llamastack-run.yaml
@@ -6,12 +6,13 @@ apis:
 - safety
 - tool_runtime
 - vector_io
+- files
 providers:
   inference:
   - provider_id: ollama
     provider_type: remote::ollama
     config:
-      url: http://ollama:11434
+      base_url: http://ollama:11434/v1
   safety:
   - provider_id: llama-guard
     provider_type: inline::llama-guard
@@ -37,6 +38,14 @@ providers:
     provider_type: remote::tavily-search
     config:
       api_key: ${env.TAVILY_API_KEY:}
+  files:
+  - provider_id: meta-reference-files
+    provider_type: inline::localfs
+    config:
+      storage_dir: /.llama/distributions/ollama/files
+      metadata_store:
+        table_name: files_metadata
+        backend: sql_default
 storage:
   backends:
     kv_default:
@@ -59,10 +68,10 @@ storage:
       backend: sql_default
 registered_resources:
   models:
-  - metadata: {}
-    model_id: llama3.2:1b
+  - model_id: llama3.2:1b
+    provider_model_id: llama3.2:1b
     provider_id: ollama
-    model_type: llm
+    metadata: {}
   shields: []
   vector_dbs: []
   datasets: []

--- a/tests/integration/test_endpoints.tavern.yaml
+++ b/tests/integration/test_endpoints.tavern.yaml
@@ -101,7 +101,7 @@ stages:
         - provider_id: "ollama"
           provider_type: "remote::ollama"
           config:
-            url: "http://ollama:11434"
+            base_url: "http://ollama:11434/v1"
           api: "inference"
         - provider_id: "llama-guard"
           provider_type: "inline::llama-guard"
@@ -130,3 +130,11 @@ stages:
           config:
             api_key: !anystr
           api: "tool_runtime"
+        - provider_id: "meta-reference-files"
+          provider_type: "inline::localfs"
+          config:
+            storage_dir: !anystr
+            metadata_store:
+              table_name: "files_metadata"
+              backend: "sql_default"
+          api: "files"


### PR DESCRIPTION
  LlamaStack Docker Hub repository was removed, breaking deployments.
  This updates to llama-stack 0.6.1 which uses ogxai/distribution-starter
  images as a replacement.

  Changes:
  - Update llama-stack Helm dependency from 0.6.10 to 0.8.6 in Chart.yaml
  - Update Python packages: llama-stack and llama_stack_client 0.3.5 → 0.6.1
  - Add version-independent helpers for API compatibility:
    * _get_model_type() - handles api_model_type vs model_type
    * _get_model_id() - handles identifier vs id
    * _get_provider_resource_id() - handles attribute vs custom_metadata
  - Update compose.yaml to use ogxai/distribution-starter:0.6.1

