### PR TITLE
Add LangGraph/CrewAI runner and MCP server support to cluster deployment

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,16 +1,15 @@
-name: Build dev image
+name: Build main images
 
 on:
   push:
     branches:
-      - dev
+      - main
 
 jobs:
-  build-dev:
+  build-main:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
       packages: write
     steps:
       - name: Checkout
@@ -26,11 +25,11 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Generate dev tag
+      - name: Generate main tag
         id: tag
         run: |
           short_sha=$(git rev-parse --short HEAD)
-          echo "value=dev-${short_sha}" >> $GITHUB_OUTPUT
+          echo "value=main-${short_sha}" >> $GITHUB_OUTPUT
 
       - name: Build and push ai-virtual-agent
         uses: docker/build-push-action@v5
@@ -40,7 +39,7 @@ jobs:
           push: true
           tags: |
             quay.io/rh-ai-quickstart/ai-virtual-agent:${{ steps.tag.outputs.value }}
-            quay.io/rh-ai-quickstart/ai-virtual-agent:latest-dev
+            quay.io/rh-ai-quickstart/ai-virtual-agent:latest-main
           cache-from: type=registry,ref=quay.io/rh-ai-quickstart/ai-virtual-agent:buildcache
           cache-to: type=registry,ref=quay.io/rh-ai-quickstart/ai-virtual-agent:buildcache,mode=max
 
@@ -52,7 +51,7 @@ jobs:
           push: true
           tags: |
             quay.io/rh-ai-quickstart/mcp-travel-research:${{ steps.tag.outputs.value }}
-            quay.io/rh-ai-quickstart/mcp-travel-research:latest-dev
+            quay.io/rh-ai-quickstart/mcp-travel-research:latest-main
 
       - name: Build and push MCP Hotel image
         uses: docker/build-push-action@v5
@@ -62,7 +61,7 @@ jobs:
           push: true
           tags: |
             quay.io/rh-ai-quickstart/mcp-hotel:${{ steps.tag.outputs.value }}
-            quay.io/rh-ai-quickstart/mcp-hotel:latest-dev
+            quay.io/rh-ai-quickstart/mcp-hotel:latest-main
 
       - name: Build and push MCP Flight image
         uses: docker/build-push-action@v5
@@ -72,4 +71,4 @@ jobs:
           push: true
           tags: |
             quay.io/rh-ai-quickstart/mcp-flight:${{ steps.tag.outputs.value }}
-            quay.io/rh-ai-quickstart/mcp-flight:latest-dev
+            quay.io/rh-ai-quickstart/mcp-flight:latest-main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,36 @@ jobs:
           cache-from: type=registry,ref=quay.io/rh-ai-quickstart/ai-virtual-agent:buildcache
           cache-to: type=registry,ref=quay.io/rh-ai-quickstart/ai-virtual-agent:buildcache,mode=max
 
+      - name: Build and push MCP Travel Research image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./mcp_servers/travel_research_mcp
+          file: ./mcp_servers/travel_research_mcp/Containerfile
+          push: true
+          tags: |
+            quay.io/rh-ai-quickstart/mcp-travel-research:${{ steps.version.outputs.value }}
+            quay.io/rh-ai-quickstart/mcp-travel-research:latest
+
+      - name: Build and push MCP Hotel image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./mcp_servers/hotel_mcp
+          file: ./mcp_servers/hotel_mcp/Containerfile
+          push: true
+          tags: |
+            quay.io/rh-ai-quickstart/mcp-hotel:${{ steps.version.outputs.value }}
+            quay.io/rh-ai-quickstart/mcp-hotel:latest
+
+      - name: Build and push MCP Flight image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./mcp_servers/flight_mcp
+          file: ./mcp_servers/flight_mcp/Containerfile
+          push: true
+          tags: |
+            quay.io/rh-ai-quickstart/mcp-flight:${{ steps.version.outputs.value }}
+            quay.io/rh-ai-quickstart/mcp-flight:latest
+
       - name: Setup Helm
         uses: azure/setup-helm@v4
 
@@ -86,9 +116,12 @@ jobs:
             --title "Release v${{ steps.version.outputs.value }}" \
             --notes "## Release v${{ steps.version.outputs.value }}
 
-          **Docker Image:**
+          **Docker Images:**
           \`\`\`
           quay.io/rh-ai-quickstart/ai-virtual-agent:${{ steps.version.outputs.value }}
+          quay.io/rh-ai-quickstart/mcp-travel-research:${{ steps.version.outputs.value }}
+          quay.io/rh-ai-quickstart/mcp-hotel:${{ steps.version.outputs.value }}
+          quay.io/rh-ai-quickstart/mcp-flight:${{ steps.version.outputs.value }}
           \`\`\`
 
           **Install Helm Chart:**

--- a/deploy/cluster/Containerfile
+++ b/deploy/cluster/Containerfile
@@ -27,7 +27,7 @@ USER root
 WORKDIR /app
 
 # Install system dependencies (cached separately)
-RUN dnf install -y nmap-ncat && dnf clean all
+RUN dnf install -y --disablerepo='rhel-*' nmap-ncat && dnf clean all
 
 # Copy only requirements first to leverage cache
 COPY backend/requirements.txt ./backend/

--- a/deploy/cluster/Makefile
+++ b/deploy/cluster/Makefile
@@ -1,7 +1,8 @@
 # AI Virtual Agent - Helm Deployment Makefile
 # Run `make help` to see available targets.
 
-.PHONY: help install install-help install-status deps uninstall install-namespace list-models list-mcps
+.PHONY: help install install-help install-status deps uninstall install-namespace list-models list-mcps \
+       build-mcp-images push-mcp-images
 
 # -----------------------------------------------------------------------------
 # Helper
@@ -11,7 +12,7 @@ help: ## Show help for helm deployment targets
 	@echo "==========================================="
 	@echo ""
 	@echo "☸️  Deployment Commands:"
-	@grep -E '^(install|install-help|install-status|deps|uninstall|list-models|list-mcps):.*?## ' $(MAKEFILE_LIST) | \
+	@grep -E '^(install|install-help|install-status|deps|uninstall|list-models|list-mcps|build-mcp-images|push-mcp-images):.*?## ' $(MAKEFILE_LIST) | \
 		sed -e 's/^/  /' -e 's/:.*## / - /'
 	@echo ""
 	@echo "For detailed deployment help, run: make install-help"
@@ -68,12 +69,20 @@ install-help: ## Show detailed deployment help and configuration options
 	@echo "Optional Configuration (set via environment variables or will be prompted):"
 	@echo "  HF_TOKEN                 - Hugging Face Token"
 	@echo "  TAVILY_API_KEY           - Tavily Search API Key"
+	@echo "  SERPAPI_API_KEY          - SerpApi API Key (hotel/flight search)"
 	@echo "  ADMIN_USERNAME           - Admin user name"
 	@echo "  ADMIN_EMAIL              - Admin user email"
 	@echo "  {SAFETY,LLM}             - Model id as defined in values (eg. llama-3-2-1b-instruct)"
 	@echo "  {SAFETY,LLM}_URL         - Model URL"
 	@echo "  {SAFETY,LLM}_API_TOKEN   - Model API token for remote models"
 	@echo "  {SAFETY,LLM}_TOLERATION  - Model pod toleration"
+	@echo ""
+	@echo "MaaS / Runner LLM Configuration:"
+	@echo "  MAAS_API_BASE            - MaaS endpoint base URL (used by LangGraph & CrewAI)"
+	@echo "  MAAS_API_KEY             - MaaS API key"
+	@echo "  MAAS_MODEL_NAME          - MaaS model name"
+	@echo "  LANGGRAPH_LLM_API_BASE   - Override LangGraph LLM base URL"
+	@echo "  CREWAI_LLM_API_BASE      - Override CrewAI LLM base URL"
 	@echo ""
 	@echo "Example usage:"
 	@echo "  make install NAMESPACE=my-ai-assistant"
@@ -126,6 +135,29 @@ uninstall: ## Uninstall deployment and clean up resources
 	@echo "If you want to completely remove the namespace, run: oc delete project $(NAMESPACE)"
 	@echo "Remaining resources in namespace $(NAMESPACE):"
 	@$(MAKE) install-status NAMESPACE=$(NAMESPACE)
+
+# -----------------------------------------------------------------------------
+# MCP Server Images
+# -----------------------------------------------------------------------------
+CONTAINER_RUNTIME ?= podman
+MCP_IMAGE_REGISTRY ?= quay.io/skattoju
+MCP_IMAGE_TAG ?= latest
+MCP_SERVERS := travel_research_mcp hotel_mcp flight_mcp
+
+build-mcp-images: ## Build container images for vacation-planner MCP servers
+	@for server in $(MCP_SERVERS); do \
+		img_name=$$(echo "mcp-$$server" | sed 's/_mcp$$//; s/_/-/g'); \
+		echo "Building $$img_name from mcp_servers/$$server ..."; \
+		$(CONTAINER_RUNTIME) build -t $(MCP_IMAGE_REGISTRY)/$$img_name:$(MCP_IMAGE_TAG) \
+			-f ../../mcp_servers/$$server/Containerfile ../../mcp_servers/$$server; \
+	done
+
+push-mcp-images: build-mcp-images ## Build and push MCP server images to registry
+	@for server in $(MCP_SERVERS); do \
+		img_name=$$(echo "mcp-$$server" | sed 's/_mcp$$//; s/_/-/g'); \
+		echo "Pushing $(MCP_IMAGE_REGISTRY)/$$img_name:$(MCP_IMAGE_TAG) ..."; \
+		$(CONTAINER_RUNTIME) push $(MCP_IMAGE_REGISTRY)/$$img_name:$(MCP_IMAGE_TAG); \
+	done
 
 install-status: ## Check deployment status
 	@echo "Deployment status for namespace: $(NAMESPACE)"

--- a/deploy/cluster/Makefile
+++ b/deploy/cluster/Makefile
@@ -140,7 +140,7 @@ uninstall: ## Uninstall deployment and clean up resources
 # MCP Server Images
 # -----------------------------------------------------------------------------
 CONTAINER_RUNTIME ?= podman
-MCP_IMAGE_REGISTRY ?= quay.io/skattoju
+MCP_IMAGE_REGISTRY ?= quay.io/rh-ai-quickstart
 MCP_IMAGE_TAG ?= latest
 MCP_SERVERS := travel_research_mcp hotel_mcp flight_mcp
 

--- a/deploy/cluster/helm/templates/deployment.yaml
+++ b/deploy/cluster/helm/templates/deployment.yaml
@@ -126,6 +126,50 @@ spec:
             - name: ADMIN_EMAIL
               value: '{{ .Values.seed.admin_user.email }}'
             {{- end }}
+            {{- with .Values.runners.langgraph.llm_api_base }}
+            - name: LANGGRAPH_LLM_API_BASE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.runners.langgraph.llm_api_key }}
+            - name: LANGGRAPH_LLM_API_KEY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.runners.langgraph.default_model }}
+            - name: LANGGRAPH_DEFAULT_MODEL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.runners.crewai.llm_api_base }}
+            - name: CREWAI_LLM_API_BASE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.runners.crewai.llm_api_key }}
+            - name: CREWAI_LLM_API_KEY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.runners.crewai.default_model }}
+            - name: CREWAI_DEFAULT_MODEL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mcp.travel_research_url }}
+            - name: TRAVEL_RESEARCH_MCP_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mcp.hotel_url }}
+            - name: HOTEL_MCP_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mcp.flight_url }}
+            - name: FLIGHT_MCP_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.apiKeys.tavily }}
+            - name: TAVILY_API_KEY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.apiKeys.serpapi }}
+            - name: SERPAPI_API_KEY
+              value: {{ . | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/cluster/helm/templates/deployment.yaml
+++ b/deploy/cluster/helm/templates/deployment.yaml
@@ -132,7 +132,10 @@ spec:
             {{- end }}
             {{- with .Values.runners.langgraph.llm_api_key }}
             - name: LANGGRAPH_LLM_API_KEY
-              value: {{ . | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-virtual-agent.fullname" $ }}-env
+                  key: LANGGRAPH_LLM_API_KEY
             {{- end }}
             {{- with .Values.runners.langgraph.default_model }}
             - name: LANGGRAPH_DEFAULT_MODEL
@@ -144,7 +147,10 @@ spec:
             {{- end }}
             {{- with .Values.runners.crewai.llm_api_key }}
             - name: CREWAI_LLM_API_KEY
-              value: {{ . | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-virtual-agent.fullname" $ }}-env
+                  key: CREWAI_LLM_API_KEY
             {{- end }}
             {{- with .Values.runners.crewai.default_model }}
             - name: CREWAI_DEFAULT_MODEL
@@ -164,11 +170,17 @@ spec:
             {{- end }}
             {{- with .Values.apiKeys.tavily }}
             - name: TAVILY_API_KEY
-              value: {{ . | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-virtual-agent.fullname" $ }}-env
+                  key: TAVILY_API_KEY
             {{- end }}
             {{- with .Values.apiKeys.serpapi }}
             - name: SERPAPI_API_KEY
-              value: {{ . | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-virtual-agent.fullname" $ }}-env
+                  key: SERPAPI_API_KEY
             {{- end }}
           ports:
             - name: http

--- a/deploy/cluster/helm/templates/secret.yaml
+++ b/deploy/cluster/helm/templates/secret.yaml
@@ -1,0 +1,21 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "ai-virtual-agent.fullname" . }}-env
+  labels:
+    {{- include "ai-virtual-agent.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- with .Values.runners.langgraph.llm_api_key }}
+  LANGGRAPH_LLM_API_KEY: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.runners.crewai.llm_api_key }}
+  CREWAI_LLM_API_KEY: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.apiKeys.tavily }}
+  TAVILY_API_KEY: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.apiKeys.serpapi }}
+  SERPAPI_API_KEY: {{ . | b64enc | quote }}
+  {{- end }}

--- a/deploy/cluster/helm/values.yaml
+++ b/deploy/cluster/helm/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: quay.io/rh-ai-quickstart/ai-virtual-agent
+  repository: quay.io/skattoju/ai-virtual-agent
   # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.1.17"
+  tag: "a2b8b20"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -119,6 +119,30 @@ pgSecret: pgvector
 
 llama_stack_url: http://llamastack:8321
 
+# Runner LLM Configuration (for LangGraph and CrewAI direct-to-model inference)
+# When set, these bypass LlamaStack and point runners at an external MaaS endpoint.
+runners:
+  langgraph:
+    llm_api_base: ""
+    llm_api_key: ""
+    default_model: ""
+  crewai:
+    llm_api_base: ""
+    llm_api_key: ""
+    default_model: ""
+
+# MCP server URLs injected into the backend pod.
+# These must match the service names created by the mcp-servers subchart.
+mcp:
+  travel_research_url: "http://mcp-travel-research:8000/mcp"
+  hotel_url: "http://mcp-hotel:8000/mcp"
+  flight_url: "http://mcp-flight:8000/mcp"
+
+# API keys passed to the backend container (for CrewAI local tool fallback)
+apiKeys:
+  tavily: ""
+  serpapi: ""
+
 sessionSecret: {}
  # value: "my-session-secret"
 
@@ -214,6 +238,38 @@ llama-stack:
       description: users can read, update and delete resources they own
   secrets:
     TAVILY_SEARCH_API_KEY: ""
+
+# Vacation-planner MCP servers deployed via the mcp-servers subchart.
+# Images must be pre-built and pushed to the repository below.
+mcp-servers:
+  mcp-servers:
+    travel-research:
+      enabled: true
+      deploymentMode: deployment
+      image:
+        repository: quay.io/skattoju/mcp-travel-research
+        tag: "latest"
+      transport: streamable-http
+      port: 8000
+      targetPort: 8000
+    hotel:
+      enabled: true
+      deploymentMode: deployment
+      image:
+        repository: quay.io/skattoju/mcp-hotel
+        tag: "latest"
+      transport: streamable-http
+      port: 8000
+      targetPort: 8000
+    flight:
+      enabled: true
+      deploymentMode: deployment
+      image:
+        repository: quay.io/skattoju/mcp-flight
+        tag: "latest"
+      transport: streamable-http
+      port: 8000
+      targetPort: 8000
 
 # global:
 #   models:

--- a/deploy/cluster/helm/values.yaml
+++ b/deploy/cluster/helm/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: quay.io/skattoju/ai-virtual-agent
+  repository: quay.io/rh-ai-quickstart/ai-virtual-agent
   # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
@@ -247,7 +247,7 @@ mcp-servers:
       enabled: true
       deploymentMode: deployment
       image:
-        repository: quay.io/skattoju/mcp-travel-research
+        repository: quay.io/rh-ai-quickstart/mcp-travel-research
         tag: "latest"
       transport: streamable-http
       port: 8000
@@ -256,7 +256,7 @@ mcp-servers:
       enabled: true
       deploymentMode: deployment
       image:
-        repository: quay.io/skattoju/mcp-hotel
+        repository: quay.io/rh-ai-quickstart/mcp-hotel
         tag: "latest"
       transport: streamable-http
       port: 8000
@@ -265,7 +265,7 @@ mcp-servers:
       enabled: true
       deploymentMode: deployment
       image:
-        repository: quay.io/skattoju/mcp-flight
+        repository: quay.io/rh-ai-quickstart/mcp-flight
         tag: "latest"
       transport: streamable-http
       port: 8000

--- a/deploy/cluster/helm/values.yaml
+++ b/deploy/cluster/helm/values.yaml
@@ -11,7 +11,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "a2b8b20"
+  tag: "1.1.17"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/deploy/cluster/scripts/collect_env_vars.sh
+++ b/deploy/cluster/scripts/collect_env_vars.sh
@@ -72,6 +72,26 @@ echo "     To enable web search, obtain a key from https://tavily.com/"
 echo ""
 TAVILY_API_KEY=$(prompt_for_value "TAVILY_API_KEY" "Enter Tavily API Key now (or press Enter to continue without web search)" "")
 
+# SerpApi API Key (optional, enables hotel and flight search in vacation planner)
+echo ""
+echo "💡 SerpApi API Key"
+echo "     Without a key, hotel and flight search will be disabled in vacation planner agents."
+echo "     To enable, obtain a key from https://serpapi.com/"
+echo ""
+SERPAPI_API_KEY=$(prompt_for_value "SERPAPI_API_KEY" "Enter SerpApi API Key now (or press Enter to skip)" "")
+
+# MaaS (Model as a Service) configuration for LangGraph / CrewAI runners
+echo ""
+echo "💡 MaaS Configuration (optional)"
+echo "     Set these to point LangGraph and CrewAI runners at an external model endpoint"
+echo "     instead of the local LlamaStack inference. Leave blank to use LlamaStack."
+echo ""
+MAAS_API_BASE=$(prompt_for_value "MAAS_API_BASE" "Enter MaaS API base URL (or press Enter to skip)" "")
+if [ -n "$MAAS_API_BASE" ]; then
+    MAAS_API_KEY=$(prompt_for_value "MAAS_API_KEY" "Enter MaaS API key" "")
+    MAAS_MODEL_NAME=$(prompt_for_value "MAAS_MODEL_NAME" "Enter MaaS model name" "")
+fi
+
 # Database configuration (use defaults, don't prompt)
 POSTGRES_USER="${POSTGRES_USER:-postgres}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-rag_password}"
@@ -86,6 +106,10 @@ export HF_TOKEN
 export ADMIN_USERNAME
 export ADMIN_EMAIL
 export TAVILY_API_KEY
+export SERPAPI_API_KEY
+export MAAS_API_BASE
+export MAAS_API_KEY
+export MAAS_MODEL_NAME
 export POSTGRES_USER
 export POSTGRES_PASSWORD
 export POSTGRES_DBNAME
@@ -98,6 +122,10 @@ if [ "$1" = "--export" ]; then
     echo "export ADMIN_USERNAME='$ADMIN_USERNAME'"
     echo "export ADMIN_EMAIL='$ADMIN_EMAIL'"
     [ -n "$TAVILY_API_KEY" ] && echo "export TAVILY_API_KEY='$TAVILY_API_KEY'"
+    [ -n "$SERPAPI_API_KEY" ] && echo "export SERPAPI_API_KEY='$SERPAPI_API_KEY'"
+    [ -n "$MAAS_API_BASE" ] && echo "export MAAS_API_BASE='$MAAS_API_BASE'"
+    [ -n "$MAAS_API_KEY" ] && echo "export MAAS_API_KEY='$MAAS_API_KEY'"
+    [ -n "$MAAS_MODEL_NAME" ] && echo "export MAAS_MODEL_NAME='$MAAS_MODEL_NAME'"
     echo "export POSTGRES_USER='$POSTGRES_USER'"
     echo "export POSTGRES_PASSWORD='$POSTGRES_PASSWORD'"
     echo "export POSTGRES_DBNAME='$POSTGRES_DBNAME'"

--- a/deploy/cluster/scripts/install_with_env.sh
+++ b/deploy/cluster/scripts/install_with_env.sh
@@ -41,6 +41,7 @@ build_helm_cmd() {
     cmd_args+=("--set" "llm-service.secret.hf_token=$HF_TOKEN")
     if [ -n "$LLM" ]; then
         cmd_args+=("--set" "global.models.$LLM.enabled=true")
+        cmd_args+=("--set" "global.models.$LLM.id=$LLM")
     fi
     if [ -n "$SAFETY" ]; then
         cmd_args+=("--set" "global.models.$SAFETY.enabled=true")
@@ -83,6 +84,50 @@ build_helm_cmd() {
     fi
     if [ -n "$ADMIN_EMAIL" ]; then
         cmd_args+=("--set" "seed.admin_user.email=$ADMIN_EMAIL")
+    fi
+
+    # Runner LLM configuration (MaaS or runner-specific overrides)
+    if [ -n "$MAAS_API_BASE" ]; then
+        cmd_args+=("--set" "runners.langgraph.llm_api_base=$MAAS_API_BASE")
+        cmd_args+=("--set" "runners.crewai.llm_api_base=$MAAS_API_BASE")
+    fi
+    if [ -n "$MAAS_API_KEY" ]; then
+        cmd_args+=("--set" "runners.langgraph.llm_api_key=$MAAS_API_KEY")
+        cmd_args+=("--set" "runners.crewai.llm_api_key=$MAAS_API_KEY")
+    fi
+    if [ -n "$MAAS_MODEL_NAME" ]; then
+        cmd_args+=("--set" "runners.langgraph.default_model=$MAAS_MODEL_NAME")
+        cmd_args+=("--set" "runners.crewai.default_model=openai/$MAAS_MODEL_NAME")
+    fi
+    # Per-runner overrides (take precedence over MaaS defaults)
+    if [ -n "$LANGGRAPH_LLM_API_BASE" ]; then
+        cmd_args+=("--set" "runners.langgraph.llm_api_base=$LANGGRAPH_LLM_API_BASE")
+    fi
+    if [ -n "$LANGGRAPH_LLM_API_KEY" ]; then
+        cmd_args+=("--set" "runners.langgraph.llm_api_key=$LANGGRAPH_LLM_API_KEY")
+    fi
+    if [ -n "$LANGGRAPH_DEFAULT_MODEL" ]; then
+        cmd_args+=("--set" "runners.langgraph.default_model=$LANGGRAPH_DEFAULT_MODEL")
+    fi
+    if [ -n "$CREWAI_LLM_API_BASE" ]; then
+        cmd_args+=("--set" "runners.crewai.llm_api_base=$CREWAI_LLM_API_BASE")
+    fi
+    if [ -n "$CREWAI_LLM_API_KEY" ]; then
+        cmd_args+=("--set" "runners.crewai.llm_api_key=$CREWAI_LLM_API_KEY")
+    fi
+    if [ -n "$CREWAI_DEFAULT_MODEL" ]; then
+        cmd_args+=("--set" "runners.crewai.default_model=$CREWAI_DEFAULT_MODEL")
+    fi
+
+    # API keys for backend and MCP server pods
+    if [ -n "$SERPAPI_API_KEY" ]; then
+        cmd_args+=("--set" "apiKeys.serpapi=$SERPAPI_API_KEY")
+        cmd_args+=("--set" "mcp-servers.mcp-servers.hotel.env.SERPAPI_API_KEY=$SERPAPI_API_KEY")
+        cmd_args+=("--set" "mcp-servers.mcp-servers.flight.env.SERPAPI_API_KEY=$SERPAPI_API_KEY")
+    fi
+    if [ -n "$TAVILY_API_KEY" ]; then
+        cmd_args+=("--set" "apiKeys.tavily=$TAVILY_API_KEY")
+        cmd_args+=("--set" "mcp-servers.mcp-servers.travel-research.env.TAVILY_API_KEY=$TAVILY_API_KEY")
     fi
 
 	# Oracle args


### PR DESCRIPTION
Author: Ganesh Murthy <gmurthy@redhat.com>
Date:   Mon Jul 13 11:12:10 2026 -0400

    feat: migrate MCP images to rh-ai-quickstart and automate builds
    
    - Update image registry from quay.io/skattoju to quay.io/rh-ai-quickstart
      - ai-virtual-agent image
      - mcp-travel-research image
      - mcp-hotel image
      - mcp-flight image
    - Add MCP server builds to all CI workflows:
      - build-dev.yml: Build MCP images on dev branch pushes
      - build-main.yml: New workflow for main branch pushes (builds all 4 images)
      - release.yml: Build MCP images during releases
    - Ensures MCP images are built and pushed whenever ai-virtual-agent is built
    - Tag strategy:
      - dev branch: {branch}-{sha}, latest-dev
      - main branch: {branch}-{sha}, latest-main
      - releases: {version}, latest

Author: Sid Kattoju <skattoju@redhat.com>
Date:   Wed Mar 11 18:06:24 2026 -0400

    feat: add LangGraph/CrewAI runner and MCP server support to cluster deployment
    
    The helm chart was missing environment variables for the LangGraph and
    CrewAI runners, causing both to fall back to OpenAI with "no-key". This
    adds runner LLM config (base URL, API key, model) and MCP server URL
    injection to the deployment template.
    
    Also configures the mcp-servers subchart to deploy the three vacation-
    planner MCP servers (travel-research, hotel, flight) and wires API keys
    to both the backend and MCP pods. Adds MaaS and SerpApi collection to
    the install scripts, a model id fix for custom LlamaStack models, and
    Makefile targets for building/pushing MCP server images.
    
    Made-with: Cursor
