### PR TITLE
fix: podman compose env-file and leftover container cleanup

### DIFF
--- a/deploy/local/scripts/start-dev.sh
+++ b/deploy/local/scripts/start-dev.sh
@@ -36,6 +36,7 @@ fi
 # Change to deploy/local directory for compose commands
 cd "$DEPLOY_LOCAL_DIR"
 COMPOSE_FILE="compose.yaml"
+ENV_FILE="$PROJECT_ROOT/.env"
 
 # Check if attachments should be enabled
 ENABLE_ATTACHMENTS=${ENABLE_ATTACHMENTS:-true}
@@ -50,11 +51,23 @@ fi
 
 # Stop any existing containers
 echo "🛑 Stopping existing containers..."
-podman compose --env-file ../../.env -f "$COMPOSE_FILE" $COMPOSE_PROFILES down --remove-orphans
+podman compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" $COMPOSE_PROFILES down --remove-orphans
+
+# Force-remove any leftover containers that compose failed to clean up.
+# This handles cases where podman loses track of compose-managed containers.
+DEV_CONTAINERS=(
+    postgresql-dev ollama-dev llamastack-dev
+    ai-va-backend-dev ai-va-frontend-dev
+    travel-research-mcp-dev hotel-mcp-dev flight-mcp-dev
+    minio-dev
+)
+for ctr in "${DEV_CONTAINERS[@]}"; do
+    podman rm -f "$ctr" 2>/dev/null || true
+done
 
 # Start all services
 echo "🏗️  Building and starting all services..."
-podman compose --env-file ../../.env -f "$COMPOSE_FILE" $COMPOSE_PROFILES up --build -d
+podman compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" $COMPOSE_PROFILES up --build -d
 
 # Wait for services to be healthy
 echo "⏳ Waiting for services to be ready..."
@@ -62,7 +75,7 @@ sleep 10
 
 # Check service status
 echo "📊 Service Status:"
-podman compose --env-file ../../.env -f "$COMPOSE_FILE" $COMPOSE_PROFILES ps
+podman compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" $COMPOSE_PROFILES ps
 
 # Show helpful information
 echo ""

--- a/deploy/local/scripts/stop-dev.sh
+++ b/deploy/local/scripts/stop-dev.sh
@@ -7,12 +7,25 @@ set -e
 # Change to deploy/local directory
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEPLOY_LOCAL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 cd "$DEPLOY_LOCAL_DIR"
 
 echo "🛑 Stopping AI Virtual Agent Development Environment..."
 
-# Stop all services (including all profiles)
-podman compose --env-file ../../.env --profile attachments down
+# Stop all services (including all profiles and orphaned containers)
+podman compose --env-file "$PROJECT_ROOT/.env" --profile attachments down --remove-orphans
+
+# Force-remove any leftover containers that compose failed to clean up.
+# This handles cases where podman loses track of compose-managed containers.
+DEV_CONTAINERS=(
+    postgresql-dev ollama-dev llamastack-dev
+    ai-va-backend-dev ai-va-frontend-dev
+    travel-research-mcp-dev hotel-mcp-dev flight-mcp-dev
+    minio-dev
+)
+for ctr in "${DEV_CONTAINERS[@]}"; do
+    podman rm -f "$ctr" 2>/dev/null || true
+done
 
 echo "✅ All services stopped successfully"
 echo ""


### PR DESCRIPTION
Pass --env-file to all podman compose commands so variables from .env are available to compose.yaml.  Force-remove known dev containers before starting to avoid "name already in use" errors when podman loses track of compose-managed containers.

Made-with: Cursor