### PR TITLE
fix: complete llama-stack 0.6.1 compatibility for models API

### DIFF
--- a/backend/app/api/v1/llama_stack.py
+++ b/backend/app/api/v1/llama_stack.py
@@ -42,6 +42,11 @@ def _get_provider_resource_id(model):
     return str(meta.get("provider_resource_id", "unknown"))
 
 
+def _get_provider_id(model):
+    """Get provider_id from various API versions"""
+    return getattr(model, "provider_id", None) or "unknown"
+
+
 def _build_env_default_entry() -> Dict[str, Any] | None:
     """Return an env-default model entry when any runner default is configured."""
     configured = []

--- a/backend/app/api/v1/models_management.py
+++ b/backend/app/api/v1/models_management.py
@@ -12,6 +12,12 @@ from ...api.llamastack import get_client_from_request
 from ...crud.virtual_agents import virtual_agents
 from ...database import get_db
 from ...schemas.models import ModelCreate, ModelRead, ModelUpdate
+from .llama_stack import (
+    _get_model_id,
+    _get_model_type,
+    _get_provider_id,
+    _get_provider_resource_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +46,15 @@ async def register_model(model_data: ModelCreate, request: Request):
 
         # Convert to response schema
         return ModelRead(
-            model_id=str(registered_model.identifier),
-            provider_id=registered_model.provider_id,
-            provider_model_id=registered_model.provider_resource_id,
-            model_type=registered_model.model_type,
-            metadata=registered_model.metadata,
+            model_id=_get_model_id(registered_model),
+            provider_id=_get_provider_id(registered_model),
+            provider_model_id=_get_provider_resource_id(registered_model),
+            model_type=_get_model_type(registered_model),
+            metadata=(
+                registered_model.metadata
+                if hasattr(registered_model, "metadata")
+                else {}
+            ),
         )
 
     except Exception as e:
@@ -79,8 +89,8 @@ async def list_models(request: Request):
 
         models_list = []
         for model in models:
-            provider_resource_id = str(model.provider_resource_id)
-            model_id = str(model.identifier)
+            provider_resource_id = _get_provider_resource_id(model)
+            model_id = _get_model_id(model)
 
             # Check if this model is used as a shield
             is_shield = (
@@ -90,9 +100,9 @@ async def list_models(request: Request):
 
             model_data = ModelRead(
                 model_id=model_id,
-                provider_id=model.provider_id,
+                provider_id=_get_provider_id(model),
                 provider_model_id=provider_resource_id,
-                model_type=model.model_type,
+                model_type=_get_model_type(model),
                 metadata=model.metadata if hasattr(model, "metadata") else {},
                 is_shield=is_shield,
             )
@@ -119,10 +129,10 @@ async def get_model(model_id: str, request: Request):
         model = await client.models.retrieve(model_id=model_id)
 
         return ModelRead(
-            model_id=str(model.identifier),
-            provider_id=model.provider_id,
-            provider_model_id=model.provider_resource_id,
-            model_type=model.model_type,
+            model_id=_get_model_id(model),
+            provider_id=_get_provider_id(model),
+            provider_model_id=_get_provider_resource_id(model),
+            model_type=_get_model_type(model),
             metadata=model.metadata if hasattr(model, "metadata") else {},
         )
 
@@ -153,22 +163,28 @@ async def update_model(model_id: str, model_data: ModelUpdate, request: Request)
         updated_model = await client.models.register(
             model_id=model_id,
             provider_model_id=model_data.provider_model_id
-            or existing_model.provider_resource_id,
-            provider_id=model_data.provider_id or existing_model.provider_id,
+            or _get_provider_resource_id(existing_model),
+            provider_id=model_data.provider_id or _get_provider_id(existing_model),
             metadata=(
                 model_data.metadata
                 if model_data.metadata is not None
-                else existing_model.metadata
+                else (
+                    existing_model.metadata
+                    if hasattr(existing_model, "metadata")
+                    else {}
+                )
             ),
-            model_type=existing_model.model_type,
+            model_type=_get_model_type(existing_model),
         )
 
         return ModelRead(
-            model_id=str(updated_model.identifier),
-            provider_id=updated_model.provider_id,
-            provider_model_id=updated_model.provider_resource_id,
-            model_type=updated_model.model_type,
-            metadata=updated_model.metadata,
+            model_id=_get_model_id(updated_model),
+            provider_id=_get_provider_id(updated_model),
+            provider_model_id=_get_provider_resource_id(updated_model),
+            model_type=_get_model_type(updated_model),
+            metadata=(
+                updated_model.metadata if hasattr(updated_model, "metadata") else {}
+            ),
         )
 
     except Exception as e:

--- a/deploy/cluster/helm/Chart.lock
+++ b/deploy/cluster/helm/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.8.6
 - name: configure-pipeline
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.5.6
+  version: 0.5.10
 - name: ingestion-pipeline
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.6.5
+  version: 0.7.9
 - name: oracle-db
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.5
-digest: sha256:929fc3fa16d5b7fb37ba194edb29bbdda3e8fd98e6f9eda37c36ffd6653ae901
-generated: "2026-06-22T15:15:22.002701642-04:00"
+digest: sha256:d2f403adaa84d9d53d494c7b330d015fe13f8c0132ffd07d99fe42cddbd697b8
+generated: "2026-08-25T10:54:11.028647485-04:00"

--- a/deploy/cluster/helm/Chart.yaml
+++ b/deploy/cluster/helm/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.17
+version: 1.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.17"
+appVersion: "1.1.18"
 
 dependencies:
   - name: pgvector
@@ -37,10 +37,10 @@ dependencies:
     version: 0.8.6
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: configure-pipeline
-    version: 0.5.6
+    version: 0.5.10
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: ingestion-pipeline
-    version: 0.6.5
+    version: 0.7.9
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: oracle-db
     version: 0.5.5

--- a/deploy/cluster/helm/values.yaml
+++ b/deploy/cluster/helm/values.yaml
@@ -11,7 +11,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.1.17"
+  tag: "1.1.18"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []


### PR DESCRIPTION
The llama-stack 0.6.1 upgrade (commit 3f4d552) added helper functions to handle API changes but forgot to update models_management.py to use them.

This commit fixes models_management.py to use the existing compatibility helpers from llama_stack.py for all Model object attribute access:
- _get_model_id() - handles identifier (0.3.x) vs id (0.6.1)
- _get_provider_resource_id() - handles direct attribute vs custom_metadata
- _get_model_type() - handles api_model_type vs model_type

Fixes AttributeError when accessing Model Providers page with llama-stack 0.6.1.

Changes:
- Import compatibility helpers from llama_stack.py
- Replace all direct Model attribute access with helper function calls
- Add hasattr() checks for metadata field which may not exist
