### PR TITLE
fix: increase MCP server healthcheck timeouts for slow CI runners

### DIFF
--- a/deploy/local/compose.yaml
+++ b/deploy/local/compose.yaml
@@ -191,8 +191,8 @@ services:
       test: ["CMD-SHELL", "python -c \"import socket; s=socket.create_connection(('localhost',7001),2); s.close()\""]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 10s
+      retries: 10
+      start_period: 30s
 
   hotel-mcp:
     build:
@@ -212,8 +212,8 @@ services:
       test: ["CMD-SHELL", "python -c \"import socket; s=socket.create_connection(('localhost',7002),2); s.close()\""]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 10s
+      retries: 10
+      start_period: 30s
 
   flight-mcp:
     build:
@@ -233,8 +233,8 @@ services:
       test: ["CMD-SHELL", "python -c \"import socket; s=socket.create_connection(('localhost',7003),2); s.close()\""]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 10s
+      retries: 10
+      start_period: 30s
 
   # MinIO service for attachments (optional - use profile 'attachments')
   minio:


### PR DESCRIPTION
MCP server containers were failing healthchecks in CI after 60s. CI runners can be slow, especially during pip install of dependencies.

Changes:
- Increase start_period: 10s → 30s (grace period before first check)
- Increase retries: 5 → 10 (more attempts)
- Total timeout now: 30s + (10 × 10s) = 130s (was 60s)

This gives containers enough time to install mcp>=1.26.0 and start the FastMCP server, even on slow GitHub Actions runners.

Fixes intermittent CI failures with 'container hotel-mcp-dev is unhealthy'